### PR TITLE
add stub class to extend the Symfony Intl Locale stub class

### DIFF
--- a/classes/Symfony/Locale.php
+++ b/classes/Symfony/Locale.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Plugin Class File
+ *
+ * Created:   March 18, 2020
+ *
+ * @package:  MWP Application Framework
+ * @author:   Kevin Carwile
+ * @since:    {plugin_version}
+ */
+namespace MWP\Framework\Symfony;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Access denied.' );
+}
+
+use Symfony\Component\Intl\Locale\Locale as IntlLocale;
+
+/**
+ * Locale Class
+ */
+class Locale extends IntlLocale
+{
+	static $available_translations;
+
+	public static function getWPAvailableTranslations() {
+		if ( ! isset( static::$available_translations ) ) {
+			include_once( ABSPATH . '/wp-admin/includes/translation-install.php' );
+			static::$available_translations = \wp_get_available_translations();
+		}
+
+		return static::$available_translations;
+	}
+
+    /**
+     * Returns the localized display name for the locale.
+     *
+     * @param string $locale   The locale code to return the display locale name from
+     * @param string $inLocale Optional format locale code to use to display the locale name
+     *
+     * @return string The localized locale display name
+     *
+     * @see http://www.php.net/manual/en/locale.getdisplayname.php
+     */
+    public static function getDisplayName($locale, $inLocale = null)
+    {
+		$translations = static::getWPAvailableTranslations();
+
+		if ( isset( $translations[ $locale ]['native_name'] ) ) {
+			return $translations[ $locale ]['native_name'];
+		} else {
+			if ( isset( $translations[ $inLocale ]['native_name'] ) ) {
+				return $translations[ $inLocale ]['native_name'];
+			}
+		}
+
+		return $locale;
+    }
+
+	
+}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "autoload": {
         "psr-4": {
             "MWP\\Framework\\": "classes/"
-        }
+        },
+        "classmap": [ "includes/stubs" ]
     },
     "extra": {
         "branch-alias": {

--- a/includes/stubs/Locale.php
+++ b/includes/stubs/Locale.php
@@ -1,0 +1,10 @@
+<?php
+
+use MWP\Framework\Symfony\Locale as IntlLocale;
+
+/**
+ * Stub implementation for the Locale class of the intl extension.
+ */
+class Locale extends IntlLocale
+{
+}


### PR DESCRIPTION
- This prevents a compatibility issue with the Facebook for Woocommerce plugin, which can inadvertently think that the PHP intl package is available when it may not be, and uses the Symfony stub class in a way that produces and uncaught exception.